### PR TITLE
Create both server and client certificates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.mod
 *.sum
+*.code-workspace
+*.crt
+*.pem

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	utilities "github.com/devgenie/miniature/internal/common"
+	"github.com/devgenie/miniature/internal/miniature"
+)
+
+func startServer(serverConfig string) {
+	config := new(miniature.ServerConfig)
+	if serverConfig != "" {
+		err := utilities.FileToYaml(serverConfig, config)
+		if err != nil {
+			log.Fatal(err)
+		}
+	} else {
+		config.CertificatesDirectory = "/etc/miniature/certs"
+		config.Network = "10.2.0.0/24"
+		config.ListeningPort = 4321
+	}
+
+	server := new(miniature.Server)
+	server.Run(*config)
+}
+
+func main() {
+	runFlag := flag.NewFlagSet("run", flag.ExitOnError)
+	serverConfigFlag := runFlag.String("config", "/etc/miniature/config.yml", "Server configuration file")
+
+	clientConfig := flag.NewFlagSet("newclient", flag.ExitOnError)
+	configFile := clientConfig.String("config", "/etc/miniature/config.yml", "Server Configuration File")
+
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "newclient":
+			serverConfig := new(miniature.ServerConfig)
+			if len(os.Args) == 3 {
+				clientConfig.Parse(os.Args[2:])
+				serverConfigYamlPath := *configFile
+				err := utilities.FileToYaml(serverConfigYamlPath, serverConfig)
+				if err != nil {
+					log.Fatal(err)
+				}
+			} else {
+				serverConfig.CertificatesDirectory = "/etc/miniature/certs"
+				serverConfig.Network = "10.2.0.0/24"
+			}
+			server := new(miniature.Server)
+			server.Config = *serverConfig
+			config, err := server.CreateClientConfig()
+			if err != nil {
+				log.Fatal(err)
+				break
+			}
+			fmt.Println(config)
+		case "run":
+			if len(os.Args) == 3 {
+				runFlag.Parse(os.Args[2:])
+				startServer(*serverConfigFlag)
+			} else {
+				startServer("")
+			}
+		default:
+			flag.Usage()
+		}
+	} else {
+		startServer("")
+	}
+}

--- a/internal/common/helpers.go
+++ b/internal/common/helpers.go
@@ -1,12 +1,15 @@
-package main
+package common
 
 import (
 	"fmt"
+	"io/ioutil"
 	"log"
+	"os"
 	"os/exec"
 	"strings"
 
 	"github.com/robfig/cron"
+	"gopkg.in/yaml.v3"
 )
 
 func RunCommand(command, arguments string) error {
@@ -28,4 +31,21 @@ func RunCron(name string, cronString string, cronFunc func()) {
 	cronjob.Start()
 	entry := cronjob.Entries()
 	fmt.Printf("Cron scheduled to run on %s \n", entry[0].Next)
+}
+
+func FileToYaml(filepath string, dataStruct interface{}) error {
+	serverConfigYamlFile, err := os.Open(filepath)
+	if err != nil {
+		return err
+	}
+
+	defer serverConfigYamlFile.Close()
+
+	serverConfigData, err := ioutil.ReadAll(serverConfigYamlFile)
+	if err != nil {
+		return nil
+	}
+
+	yaml.Unmarshal(serverConfigData, dataStruct)
+	return nil
 }

--- a/internal/common/ifce.go
+++ b/internal/common/ifce.go
@@ -1,4 +1,4 @@
-package main
+package common
 
 import (
 	"bufio"
@@ -13,15 +13,15 @@ import (
 )
 
 type Tun struct {
-	ifce       *water.Interface
-	name       string
-	ip         net.IP
-	remote     net.IP
-	subnetMask net.IPMask
-	mtu        string
+	Ifce       *water.Interface
+	Name       string
+	Ip         net.IP
+	Remote     net.IP
+	SubnetMask net.IPMask
+	Mtu        string
 }
 
-func newInterface() (*Tun, error) {
+func NewInterface() (*Tun, error) {
 	config := water.Config{
 		DeviceType: water.TUN,
 	}
@@ -31,38 +31,38 @@ func newInterface() (*Tun, error) {
 		return nil, err
 	}
 	ifce := new(Tun)
-	ifce.ifce = tunInterface
+	ifce.Ifce = tunInterface
 	return ifce, nil
 }
 
 func (tun *Tun) Configure(ifceAddr net.IP, remote net.IP, mtu string) error {
 	ipaddr := ifceAddr.String()
-	command := fmt.Sprintf("link set dev %s mtu %s", tun.ifce.Name(), mtu)
+	command := fmt.Sprintf("link set dev %s mtu %s", tun.Ifce.Name(), mtu)
 	err := RunCommand("ip", command)
 	if err != nil {
-		log.Fatalf("Error configuring interface %s, message: %s \n", tun.ifce.Name(), err)
+		log.Fatalf("Error configuring interface %s, message: %s \n", tun.Ifce.Name(), err)
 		return err
 	}
 
-	tun.mtu = mtu
-	command = fmt.Sprintf("add add dev %s local %s peer %s", tun.ifce.Name(), ipaddr, remote.String())
+	tun.Mtu = mtu
+	command = fmt.Sprintf("add add dev %s local %s peer %s", tun.Ifce.Name(), ipaddr, remote.String())
 	err = RunCommand("ip", command)
 	if err != nil {
-		log.Fatalf("Error configuring interface %s, message: %s \n", tun.ifce.Name(), err)
+		log.Fatalf("Error configuring interface %s, message: %s \n", tun.Ifce.Name(), err)
 		return err
 	}
 
-	command = fmt.Sprintf("link set dev %s up", tun.ifce.Name())
+	command = fmt.Sprintf("link set dev %s up", tun.Ifce.Name())
 	err = RunCommand("ip", command)
 	if err != nil {
-		log.Printf("Error configuring interface %s, message: %s \n", tun.ifce.Name(), err)
+		log.Printf("Error configuring interface %s, message: %s \n", tun.Ifce.Name(), err)
 		return err
 	}
-	tun.ip = ifceAddr
+	tun.Ip = ifceAddr
 	return nil
 }
 
-func getDefaultGateway() (ifaceName string, gateway string, err error) {
+func GetDefaultGateway() (ifaceName string, gateway string, err error) {
 	routeFile, err := os.Open("/proc/net/route")
 	if err != nil {
 		log.Println("Error reading /proc/net/route")

--- a/internal/common/tplink.go
+++ b/internal/common/tplink.go
@@ -1,4 +1,4 @@
-package main
+package common
 
 import (
 	"bytes"
@@ -41,7 +41,7 @@ type TCP struct {
 	Tcp_fin     []byte
 }
 
-func decode(dataStructure interface{}, data []byte) error {
+func Decode(dataStructure interface{}, data []byte) error {
 	buffer := bytes.NewBuffer(data)
 	decoder := gob.NewDecoder(buffer)
 	err := decoder.Decode(dataStructure)
@@ -54,7 +54,7 @@ func decode(dataStructure interface{}, data []byte) error {
 	return nil
 }
 
-func encode(dataStructure interface{}) (encoded []byte, err error) {
+func Encode(dataStructure interface{}) (encoded []byte, err error) {
 	var buffer bytes.Buffer
 	encoder := gob.NewEncoder(&buffer)
 	err = encoder.Encode(dataStructure)

--- a/internal/miniature/client.go
+++ b/internal/miniature/client.go
@@ -7,11 +7,12 @@ import (
 	"strconv"
 	"sync"
 
+	utilities "github.com/devgenie/miniature/internal/common"
 	"golang.org/x/net/ipv4"
 )
 
 type Client struct {
-	ifce        *Tun
+	ifce        *utilities.Tun
 	conn        *net.UDPConn
 	waiter      sync.WaitGroup
 	sessionChan chan string
@@ -25,7 +26,7 @@ type ClientConfig struct {
 }
 
 func NewClient(server string) {
-	_, err := newInterface()
+	_, err := utilities.NewInterface()
 	if err != nil {
 		log.Printf("Failed to create interface")
 	}
@@ -58,10 +59,10 @@ func (client *Client) listen(server string, port string) {
 
 func (client *Client) greetServer() {
 	fmt.Println("Greeting server")
-	packetHeader := PacketHeader{Flag: HANDSHAKE}
-	packet := Packet{PacketHeader: packetHeader, Payload: make([]byte, 0)}
+	packetHeader := utilities.PacketHeader{Flag: utilities.HANDSHAKE}
+	packet := utilities.Packet{PacketHeader: packetHeader, Payload: make([]byte, 0)}
 
-	encodedData, err := encode(&packet)
+	encodedData, err := utilities.Encode(&packet)
 
 	if err != nil {
 		log.Printf("An error occured while encoding data returned \n Error: %s \n", err)
@@ -75,13 +76,13 @@ func (client *Client) greetServer() {
 func (client *Client) handleServerGreeting(packet []byte) {
 	fmt.Println("Handling Server greeting")
 	fmt.Println("Configuring new tun interface")
-	ifce, err := newInterface()
+	ifce, err := utilities.NewInterface()
 	if err != nil {
 		log.Println("Error creating tun interface")
 	}
 
-	ipAddr := new(Addr)
-	err = decode(ipAddr, packet)
+	ipAddr := new(utilities.Addr)
+	err = utilities.Decode(ipAddr, packet)
 	if err != nil {
 		log.Printf("An error occurred trying to decode data from the server \t Error: %s \n", err)
 		return
@@ -96,17 +97,17 @@ func (client *Client) handleServerGreeting(packet []byte) {
 	client.ifce = ifce
 
 	peer := new(Peer)
-	peer.IP = ifce.ip.String()
-	encodedPeer, err := encode(&peer)
+	peer.IP = ifce.Ip.String()
+	encodedPeer, err := utilities.Encode(&peer)
 	if err != nil {
 		log.Printf("An error occured while encording peer data \t Error : %s \n", err)
 		return
 	}
 
-	packetHeader := PacketHeader{Flag: CLIENT_CONFIGURATION}
-	sendPacket := Packet{PacketHeader: packetHeader, Payload: encodedPeer}
+	packetHeader := utilities.PacketHeader{Flag: utilities.CLIENT_CONFIGURATION}
+	sendPacket := utilities.Packet{PacketHeader: packetHeader, Payload: encodedPeer}
 
-	encodedPacket, err := encode(&sendPacket)
+	encodedPacket, err := utilities.Encode(&sendPacket)
 
 	if err != nil {
 		log.Printf("An error occured while encording peer data \t Error : %s \n", err)
@@ -120,7 +121,7 @@ func (client *Client) handleIncomingConnections() {
 	defer client.waiter.Done()
 
 	inputBytes := make([]byte, 2048)
-	packet := new(Packet)
+	packet := new(utilities.Packet)
 
 	for {
 		length, err := client.conn.Read(inputBytes)
@@ -130,7 +131,7 @@ func (client *Client) handleIncomingConnections() {
 		}
 
 		fmt.Printf("Recieved %s bytes \n", length)
-		err = decode(packet, inputBytes)
+		err = utilities.Decode(packet, inputBytes)
 		if err != nil {
 			log.Printf("Error decoding data from the server \t Error : %s \n", err)
 			continue
@@ -140,26 +141,26 @@ func (client *Client) handleIncomingConnections() {
 		headerFlag := packetHeader.Flag
 
 		switch headerFlag {
-		case HANDSHAKE_ACCEPTED:
+		case utilities.HANDSHAKE_ACCEPTED:
 			client.handleServerGreeting(packet.Payload)
-		case SESSION_ACCEPTED:
-			fmt.Printf("Starting session, MTU of link is %s \n", client.ifce.mtu)
+		case utilities.SESSION_ACCEPTED:
+			fmt.Printf("Starting session, MTU of link is %s \n", client.ifce.Mtu)
 
 			command := "route delete 0.0.0.0/0"
-			err := RunCommand("ip", command)
+			err := utilities.RunCommand("ip", command)
 			if err != nil {
 				log.Printf("Error cdeleting route message: %s \n", err)
 			}
 
-			command = fmt.Sprintf("route add 0.0.0.0/0 via %s dev %s", client.ifce.ip.String(), client.ifce.ifce.Name())
-			err = RunCommand("ip", command)
+			command = fmt.Sprintf("route add 0.0.0.0/0 via %s dev %s", client.ifce.Ip.String(), client.ifce.Ifce.Name())
+			err = utilities.RunCommand("ip", command)
 			if err != nil {
 				log.Printf("Error adding route to 0.0.0.0/0, message: %s \n", err)
 			}
 
-			client.sessionChan <- client.ifce.mtu
+			client.sessionChan <- client.ifce.Mtu
 			client.StartHeartBeat()
-		case SESSION:
+		case utilities.SESSION:
 			client.writeToIfce(packet.Payload)
 		default:
 			fmt.Println("Expected headers not found")
@@ -168,7 +169,7 @@ func (client *Client) handleIncomingConnections() {
 }
 
 func (client *Client) writeToIfce(packet []byte) {
-	client.ifce.ifce.Write(packet)
+	client.ifce.Ifce.Write(packet)
 }
 
 func (client *Client) handleOutgoingConnections() {
@@ -184,7 +185,7 @@ func (client *Client) handleOutgoingConnections() {
 	packetSize = packetSize - 400
 	buffer := make([]byte, packetSize)
 	for {
-		length, err := client.ifce.ifce.Read(buffer)
+		length, err := client.ifce.Ifce.Read(buffer)
 		if err != nil {
 			fmt.Println(err)
 			continue
@@ -197,9 +198,9 @@ func (client *Client) handleOutgoingConnections() {
 				continue
 			}
 
-			packetHeader := PacketHeader{Flag: SESSION}
-			sendPacket := Packet{PacketHeader: packetHeader, Payload: buffer[:length]}
-			encodedPacket, err := encode(sendPacket)
+			packetHeader := utilities.PacketHeader{Flag: utilities.SESSION}
+			sendPacket := utilities.Packet{PacketHeader: packetHeader, Payload: buffer[:length]}
+			encodedPacket, err := utilities.Encode(sendPacket)
 			if err != nil {
 				log.Printf("An error occured while trying to encode this packet \t Error : %s \n", err)
 				return
@@ -214,21 +215,21 @@ func (client *Client) handleOutgoingConnections() {
 }
 
 func (client *Client) StartHeartBeat() {
-	RunCron("Heartbeat", "0 0/1 * * * *", client.HeartBeat)
+	utilities.RunCron("Heartbeat", "0 0/1 * * * *", client.HeartBeat)
 }
 
 func (client *Client) HeartBeat() {
 	peer := new(Peer)
-	peer.IP = client.ifce.ip.String()
-	encodedPeer, err := encode(&peer)
+	peer.IP = client.ifce.Ip.String()
+	encodedPeer, err := utilities.Encode(&peer)
 	if err != nil {
 		log.Printf("An error occured while encording peer data \t Error : %s \n", err)
 		return
 	}
 
-	packetHeader := PacketHeader{Flag: HEARTBEAT}
-	sendPacket := Packet{PacketHeader: packetHeader, Payload: encodedPeer}
-	encodedPacket, err := encode(sendPacket)
+	packetHeader := utilities.PacketHeader{Flag: utilities.HEARTBEAT}
+	sendPacket := utilities.Packet{PacketHeader: packetHeader, Payload: encodedPeer}
+	encodedPacket, err := utilities.Encode(sendPacket)
 	if err != nil {
 		log.Printf("An error occured while trying to encode this packet \t Error : %s \n", err)
 		return


### PR DESCRIPTION
The server should be able to create certificates if they have not been found in the path specified in the configuration file. It should also be able to create client certificates from the previously generated CA certificate. At the moment, the CA is self-signed. The client certificate generated is bundled into a configuration file which is output to the terminal.

This PR does the following:
1 - Changes the project structure to easily isolate the server and client binaries
2 - Creates an independent server module that can be compiled into its own binary
3 - Provides a cleaner way to run the server
4 - Provides an option to create client certificates

To start the server, run with default settings;
`./server run`

To run the server with a custom configuration file;
`./server run -config=path/to/config.yml`

To create a client certificate, run;
`./server newclient -config=path/to/config.yml`

The config is in the format
```
certificatesdirectory: /etc/miniature/certs
network: 10.2.0.0/24
listeningport: 4321
```

The default path for the configuration file is `/etc/miniature/` while the one for the server's certificates is `/etc/miniature/certs`

Fixes #8 
Fixes #9 