### PR TITLE
Load client configuration file as commandline argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,102 @@ export GO111MODULE=on
 
 go mod init github.com/devgenie/miniature
 
-go build
 ```
 
-To run the VPN server:
+To build and run the VPN server
 
-`` ./miniature --type=server ``
+```
+go build ./cmd/server
 
-To run the VPN client:
+./server run -config=/etc/miniature/config.yml
+```
 
-`` ./minature --type=client --remote=remote-server-address ``
+`-config` is the path to the VPN server's configuration file, the VPN server's configuration file looks like;
+
+```
+certificatesdirectory: /etc/miniature/certs
+
+network: 10.2.0.0/24
+
+listeningport: 4321
+```
+
+You can also start the server using `./server run`. This will use the default path to the configuration file (`/etc/miniature/config.yml`)
+
+To create a client configuration file
+`./server newclient --config=/etc/miniature/config.yml`
+
+`-config` is the path to the server configuration file, you can also create the client configuration file using `./server newclient`, this uses the server's default path to the configuration file, in this case which is `/etc/miniature/config.yml`
+
+
+To build and run the VPN client:
+
+```
+go build ./cmd/client
+
+./client -config=/etc/miniature/config.yml
+```
+
+`-config` is used to specify the path to the  client configuration file. If this command line switch is not provided, the client will use the default path which is `/etc/miniature/config.yml`. The config file takes the following shape:
+
+```
+serveraddress: 172.2.2.2
+listeningport: 4321
+certificate: |
+    -----BEGIN CERTIFICATE-----
+    MIIDwDCCAqigAwIBAgIIEt8f19aYOP4wDQYJKoZIhvcNAQELBQAwcDEPMA0GA1UE
+    BhMGVWdhbmRhMQkwBwYDVQQIEwAxCTAHBgNVBAcTADEJMAcGA1UECRMAMQkwBwYD
+    VQQREwAxEjAQBgNVBAoTCUdlbmllTGFiczEJMAcGA1UECxMAMRIwEAYDVQQDEwlH
+    ZW5pZUxhYnMwHhcNMTkwNzAyMjMyMjAwWhcNMjQxMjA3MjMyMjAwWjBwMQ8wDQYD
+    VQQGEwZVZ2FuZGExCTAHBgNVBAgTADEJMAcGA1UEBxMAMQkwBwYDVQQJEwAxCTAH
+    BgNVBBETADESMBAGA1UEChMJR2VuaWVMYWJzMQkwBwYDVQQLEwAxEjAQBgNVBAMT
+    CUdlbmllTGFiczCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKsjiB4T
+    IZb5muzLVRCWf3Z1f7kub4l9/psyLL6FyOfdjvdbOP+fc1XxFd40G2fROFCAiZOw
+    2SFg/HLxDJt/RqX38e40Uto+RjUAj67k+B59A4JIP52+tqv4N9J1Q1IoQEKotQIB
+    Ej6Ug5evKp2cQ7Ui731IvGzTwuacYoU6UkU+1rfw4L0SdAC1hjQ6S11WzitcRNTu
+    aCx6tj+F+C/bvTwcneHmJjHbOT135jWyjLKSZzv1zNP3C8fDdj6/auTsCW7kSIyt
+    G8e3c0/tpmP6YG5TeYyVOysPMnfcqJPDnJPrWIztOxYmhv1etPXR0wxZp83i6Rhe
+    jHqyi9A2tPQiL0kCAwEAAaNeMFwwDgYDVR0PAQH/BAQDAgKEMB0GA1UdJQQWMBQG
+    CCsGAQUFBwMCBggrBgEFBQcDATAMBgNVHRMBAf8EAjAAMB0GA1UdDgQWBBQAxYvP
+    p4gWbBUK7RxG6dTdQ922qTANBgkqhkiG9w0BAQsFAAOCAQEArSBO+rMyoAWkCiBu
+    6RGdYy80KoCVKF3wNL8fEiXvMXZcnlyxF1GGyKTEWTVlelzMvauvNdhbtDEWKGqt
+    UD3euOV+S6+/JNbHLIOlcj4N4pZRlSw8iTf9MPb7dGu/h4StXbIwSFgkVwyeiHWD
+    vFaP1djY/6Ng1QDfaGN1fe/iFACvEpJAdiizq16eee3/y2ywFzZEqtk5mNoXSvHI
+    MS9dGE1YxIYJtPeqw2ZsTtRIa+1XsCiUp0nqRya9bK1eJFmO7oYFKZnSQ89JnNeN
+    5eVwLDYsbrfU14kWHf9e2S3LXYqGROVSyIgVsMSyjcZJ1ipLFl9xqg3AY5O0yHRq
+    y4ylDg==
+    -----END CERTIFICATE-----
+privatekey: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEpAIBAAKCAQEAqyOIHhMhlvma7MtVEJZ/dnV/uS5viX3+mzIsvoXI592O91s4
+    /59zVfEV3jQbZ9E4UICJk7DZIWD8cvEMm39Gpffx7jRS2j5GNQCPruT4Hn0Dgkg/
+    nb62q/g30nVDUihAQqi1AgESPpSDl68qnZxDtSLvfUi8bNPC5pxihTpSRT7Wt/Dg
+    vRJ0ALWGNDpLXVbOK1xE1O5oLHq2P4X4L9u9PByd4eYmMds5PXfmNbKMspJnO/XM
+    0/cLx8N2Pr9q5OwJbuRIjK0bx7dzT+2mY/pgblN5jJU7Kw8yd9yok8Ock+tYjO07
+    FiaG/V609dHTDFmnzeLpGF6MerKL0Da09CIvSQIDAQABAoIBAEJBM0VRasOkRpI9
+    9eTCHv6hZp0umQfFu3gh6Kip6qm5YMvqiRqNhH1VJH4t9h4vJXolCR4gbS86+QEW
+    ySa6E4PVhdgOcbUEPvHuEbJH+rby9xTNG7PaTaYuJo5Xz4RTCO3Fmq339DQ+EuP6
+    cKksAhpyN/1s12XaZa4aBRpHBerAUq8N01rYWgJ1uH/7ILKtaZMg/tBbUHqqPd0G
+    oWcub/zbAmGmU3MqZMtY8VG1DsDQ8nlGsFdJnyHX9NFisPOiP3ytk1kBuIHN3yQT
+    S3AG1FWu/PkYqZtho+dl4MI/osMmRoZLY62zDMASByeqQ5bO619UQ5TPl0XXDnkz
+    tuplecECgYEAwwdym/yaykcjv34A8sgkSvPMr4TCsUkPZNAoijZWjuXlD9iMDKhK
+    ITFiZtOHxdS9yNmWr7KUB6t3Amw7BAVRUU+9prYGi3069BVnMZP5PGa0xM8/UgqW
+    KtrljHDydWGYq/9vNCFNDVg5CW7uBZEc2jZtL+fuKtbLcMpoG/5aWo0CgYEA4KQZ
+    BdMd0HEL1W0EBjs2/WuElfxSnMvSZAxRYMJFDudma3tw5EnHvbSG3E32oLU7YYpG
+    emvpL9NB2fVkiN99ylWqciXdjuxsv0y+POvpCuFyXVH2g5T/g7+TYU+SV/aKRcBd
+    wpOYl8MbLzPlgVpHZUe2l48XGv8sHfdgaj4udq0CgYARm7GITdU34BZlKp4xTUqh
+    jcN0MVtWoE8Ifha6688C1dTJinaSifsvZgMJX53JibyczrBhKpFc4+k5ycXGRiii
+    W722uIZ8v5C8CtanTkHZZzh48HE6GgSW1+6TsHrjiC09kjFbFoqbYtS7ek15KTHe
+    rb1L7ve83Gm/xDaEGIHV3QKBgQDax5bDMHhB8Ec5JgIcW4FT0GoBdQu0P2F5JPIA
+    jVOaj00VctRg0WZh4LbTSm7e14KsnXHEeuJRPKtOrgqqrxcgfswQfcZJEwNaUFCa
+    npuJiEXMky3FutAbLPJJfKinWKoUAqSOAxdC/ra0AxQLJbSQ9AXll2tGVKxPxwQ0
+    lLjFxQKBgQCUkn1Y2yad4fLb+prcurtuIwBSqpXt/eX/SmT87b0G50VPR0vZQzNw
+    v7tHAZear2HgMdM8s4c2h6Ye+hBDssEqg9TP6JrXcmXUOG8UST4w3PF8DPtJH/Vr
+    bKLdmSN6GJJcT7lcwtXYNA6/ygkuMzySfBPLItkHQ+yPI9b2P8YKGA==
+    -----END RSA PRIVATE KEY-----
+```
+
+This config file can be got from running `./server newclient --config=/etc/miniature/config.yml`
 
 **Note**
 

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"flag"
+	"log"
+
+	utilities "github.com/devgenie/miniature/internal/common"
+	"github.com/devgenie/miniature/internal/miniature"
+)
+
+func main() {
+	configFile := flag.String("config", "/etc/miniature/config.yml", "Client configuration file")
+	flag.Parse()
+
+	if *configFile != "" {
+		clientConfig := new(miniature.ClientConfig)
+		err := utilities.FileToYaml(*configFile, clientConfig)
+		if err != nil {
+			log.Fatal(err)
+		}
+		vpnClient := new(miniature.Client)
+		vpnClient.Run(*clientConfig)
+	} else {
+		log.Fatal("Please provide path to config file")
+	}
+}

--- a/internal/common/helpers.go
+++ b/internal/common/helpers.go
@@ -34,18 +34,18 @@ func RunCron(name string, cronString string, cronFunc func()) {
 }
 
 func FileToYaml(filepath string, dataStruct interface{}) error {
-	serverConfigYamlFile, err := os.Open(filepath)
+	file, err := os.Open(filepath)
 	if err != nil {
 		return err
 	}
 
-	defer serverConfigYamlFile.Close()
+	defer file.Close()
 
-	serverConfigData, err := ioutil.ReadAll(serverConfigYamlFile)
+	fileData, err := ioutil.ReadAll(file)
 	if err != nil {
 		return nil
 	}
 
-	yaml.Unmarshal(serverConfigData, dataStruct)
+	yaml.Unmarshal(fileData, dataStruct)
 	return nil
 }

--- a/internal/miniature/client.go
+++ b/internal/miniature/client.go
@@ -16,6 +16,7 @@ type Client struct {
 	conn        *net.UDPConn
 	waiter      sync.WaitGroup
 	sessionChan chan string
+	config      ClientConfig
 }
 
 type ClientConfig struct {
@@ -25,14 +26,15 @@ type ClientConfig struct {
 	PrivateKey    string
 }
 
-func NewClient(server string) {
+func (client *Client) Run(config ClientConfig) {
 	_, err := utilities.NewInterface()
 	if err != nil {
 		log.Printf("Failed to create interface")
 	}
-
-	client := new(Client)
-	client.listen(server, "4321")
+	client.config = config
+	fmt.Println(client.config.ServerAddress)
+	fmt.Println(client.config.ListeningPort)
+	client.listen(client.config.ServerAddress, strconv.Itoa(client.config.ListeningPort))
 	defer client.conn.Close()
 	//incoming := make(chan []byte)
 	client.sessionChan = make(chan string)


### PR DESCRIPTION
Pass the configuration file as an argument to the VPN client. The command to start the client looks like `client -config=/etc/miniature/config.yml`. You can also start the client without the -config parameter, it will use the default path which is `/etc/miniature/config.yml`