### PR TITLE
Authenticate clients using RSA certificates

### DIFF
--- a/internal/common/tplink.go
+++ b/internal/common/tplink.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"bytes"
+	"crypto"
 	"encoding/gob"
 	"log"
 	"net"
@@ -11,9 +12,10 @@ const (
 	HANDSHAKE            byte = 0x01
 	HANDSHAKE_ACCEPTED   byte = 0x02
 	CLIENT_CONFIGURATION byte = 0x03
-	SESSION_ACCEPTED     byte = 0x04
-	HEARTBEAT            byte = 0x05
-	SESSION              byte = 0x06
+	SESSION_REQUEST      byte = 0x04
+	SESSION_ACCEPTED     byte = 0x05
+	HEARTBEAT            byte = 0x06
+	SESSION              byte = 0x07
 )
 
 type Addr struct {
@@ -29,9 +31,9 @@ type PacketHeader struct {
 
 type Packet struct {
 	PacketHeader
-	Payload []byte
+	PublicKey crypto.PublicKey
+	Payload   []byte
 }
-
 type TCP struct {
 	Tcp_src     string
 	Tcp_dst     string


### PR DESCRIPTION
Read RSA certificates and CA certificate from the client's configuration and use this data to authenticate the server. The server also uses a CA certificate to authenticate that the client has been signed by the CA. Once the authentication is done, the client initiates the DH key exchange passing its public key to the server which uses this data to compute a secret. The server passes the generated public key back to the client which in turn also creates a secret to be used for encrypting and decrypting data.  

closes #10