### PR TITLE
Add the server's public address to client configuration

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -23,7 +23,6 @@ func startServer(serverConfig string) {
 		config.ListeningPort = 4321
 	}
 
-	log.Println(config.Metadata.Country)
 	server := new(miniature.Server)
 	server.Run(*config)
 }

--- a/internal/common/helpers.go
+++ b/internal/common/helpers.go
@@ -1,9 +1,11 @@
 package common
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
+	"net"
 	"os"
 	"os/exec"
 	"strings"
@@ -48,4 +50,26 @@ func FileToYaml(filepath string, dataStruct interface{}) error {
 
 	yaml.Unmarshal(fileData, dataStruct)
 	return nil
+}
+
+func GetPublicIP(interfaceName string) (ipaddress string, err error) {
+	interfaceByname, err := net.InterfaceByName(interfaceName)
+	if err != nil {
+		return "", err
+	}
+
+	var publicIpAddress string
+	ipAddresses, err := interfaceByname.Addrs()
+	for _, ipAddr := range ipAddresses {
+		addr := ipAddr.(*net.IPNet)
+		if !addr.IP.IsLoopback() {
+			publicIpAddress = addr.IP.String()
+			break
+		}
+	}
+
+	if len(strings.TrimSpace(publicIpAddress)) > 0 {
+		return publicIpAddress, nil
+	}
+	return "", errors.New("Could not find a public IP address")
 }


### PR DESCRIPTION
There are other ways of getting the public IP address but these involve relying on an external website which in cases where the site goes down, will make it impossible to retrieve the IP address. This method loops through the provided interface's IP addresses and gets the first non-loopback address found.

The VPN server's public address is retrieved from the gateway interface and is added to the client configuration.

closes #19 