### PR TITLE
Ft m11 Encrypt and decrypt packets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-*.mod
+.mod
 *.sum
 *.code-workspace
 *.crt

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -1,12 +1,18 @@
 package main
 
 import (
+	"encoding/gob"
 	"flag"
 	"log"
 
+	"github.com/aead/ecdh"
 	utilities "github.com/devgenie/miniature/internal/common"
 	"github.com/devgenie/miniature/internal/miniature"
 )
+
+func init() {
+	gob.Register(ecdh.Point{})
+}
 
 func main() {
 	configFile := flag.String("config", "/etc/miniature/config.yml", "Client configuration file")

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -17,7 +17,6 @@ func startServer(serverConfig string) {
 		if err != nil {
 			log.Fatal(err)
 		}
-		log.Println(config.CertificatesDirectory)
 	} else {
 		config.CertificatesDirectory = "/etc/miniature/certs"
 		config.Network = "10.2.0.0/24"

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -17,6 +17,7 @@ func startServer(serverConfig string) {
 		if err != nil {
 			log.Fatal(err)
 		}
+		log.Println(config.CertificatesDirectory)
 	} else {
 		config.CertificatesDirectory = "/etc/miniature/certs"
 		config.Network = "10.2.0.0/24"

--- a/dockerfile
+++ b/dockerfile
@@ -8,5 +8,3 @@ RUN mkdir /miniature
 COPY . /miniature
 WORKDIR /miniature
 RUN export GO111MODULE=on
-RUN go mod init github.com/devgenie/miniature
-RUN CGO_ENABLED=1 GOOS=linux go build

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,19 @@
+module github.com/devgenie/miniature
+
+go 1.12
+
+require (
+	github.com/aead/ecdh v0.2.0
+	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
+	github.com/robfig/cron v1.2.0
+	github.com/songgao/water v0.0.0-20190623021929-8567d1527789
+	github.com/spacemonkeygo/openssl v0.0.0-20181017203307-c2dcc5cca94a
+	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 // indirect
+	golang.org/x/net v0.0.0-20190628185345-da137c7871d7
+	golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb // indirect
+	golang.org/x/text v0.3.2 // indirect
+	golang.org/x/tools v0.0.0-20190703172252-a00916dd39a5 // indirect
+	golang.org/x/tools/gopls v0.1.2-0.20190703172252-a00916dd39a5 // indirect
+	gopkg.in/yaml.v2 v2.2.2
+	gopkg.in/yaml.v3 v3.0.0-20190502103701-55513cacd4ae
+)

--- a/internal/common/helpers.go
+++ b/internal/common/helpers.go
@@ -68,6 +68,9 @@ func GetPublicIP(interfaceName string) (ipaddress string, err error) {
 
 	var publicIPAddress string
 	ipAddresses, err := interfaceByname.Addrs()
+	if err != nil {
+		return "", err
+	}
 	for _, ipAddr := range ipAddresses {
 		addr := ipAddr.(*net.IPNet)
 		if !addr.IP.IsLoopback() {

--- a/internal/common/helpers.go
+++ b/internal/common/helpers.go
@@ -41,19 +41,22 @@ func RunCron(name string, cronString string, cronFunc func()) {
 func FileToYaml(filepath string, dataStruct interface{}) error {
 	file, err := os.Open(filepath)
 	if err != nil {
+		file.Close()
 		return err
 	}
 
-	defer file.Close()
-
 	fileData, err := ioutil.ReadAll(file)
 	if err != nil {
-		return nil
+		file.Close()
+		return err
 	}
 
 	err = yaml.Unmarshal(fileData, dataStruct)
-	fmt.Println(err)
-	return nil
+	if err != nil {
+		file.Close()
+		return err
+	}
+	return file.Close()
 }
 
 // GetPublicIP gets the public ip of the host

--- a/internal/common/helpers.go
+++ b/internal/common/helpers.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// RunCommand is a wrapper to easily run linux commands
 func RunCommand(command, arguments string) error {
 	log.Printf("Issuing command: %s %s \n", command, arguments)
 	commandArguments := strings.Split(arguments, " ")
@@ -22,6 +23,7 @@ func RunCommand(command, arguments string) error {
 	return err
 }
 
+// RunCron runs cron jobs
 func RunCron(name string, cronString string, cronFunc func()) {
 	cronjob := cron.New()
 	err := cronjob.AddFunc(cronString, cronFunc)
@@ -35,6 +37,7 @@ func RunCron(name string, cronString string, cronFunc func()) {
 	fmt.Printf("Cron scheduled to run on %s \n", entry[0].Next)
 }
 
+// FileToYaml unmarshals files to the data stucture specified
 func FileToYaml(filepath string, dataStruct interface{}) error {
 	file, err := os.Open(filepath)
 	if err != nil {
@@ -48,28 +51,30 @@ func FileToYaml(filepath string, dataStruct interface{}) error {
 		return nil
 	}
 
-	yaml.Unmarshal(fileData, dataStruct)
+	err = yaml.Unmarshal(fileData, dataStruct)
+	fmt.Println(err)
 	return nil
 }
 
+// GetPublicIP gets the public ip of the host
 func GetPublicIP(interfaceName string) (ipaddress string, err error) {
 	interfaceByname, err := net.InterfaceByName(interfaceName)
 	if err != nil {
 		return "", err
 	}
 
-	var publicIpAddress string
+	var publicIPAddress string
 	ipAddresses, err := interfaceByname.Addrs()
 	for _, ipAddr := range ipAddresses {
 		addr := ipAddr.(*net.IPNet)
 		if !addr.IP.IsLoopback() {
-			publicIpAddress = addr.IP.String()
+			publicIPAddress = addr.IP.String()
 			break
 		}
 	}
 
-	if len(strings.TrimSpace(publicIpAddress)) > 0 {
-		return publicIpAddress, nil
+	if len(strings.TrimSpace(publicIPAddress)) > 0 {
+		return publicIPAddress, nil
 	}
 	return "", errors.New("Could not find a public IP address")
 }

--- a/internal/common/ifce.go
+++ b/internal/common/ifce.go
@@ -12,15 +12,17 @@ import (
 	"github.com/songgao/water"
 )
 
+// Tun represents a Tun interface
 type Tun struct {
 	Ifce       *water.Interface
 	Name       string
-	Ip         net.IP
+	IP         net.IP
 	Remote     net.IP
 	SubnetMask net.IPMask
 	Mtu        string
 }
 
+// NewInterface creates a new Tun interface
 func NewInterface() (*Tun, error) {
 	config := water.Config{
 		DeviceType: water.TUN,
@@ -35,6 +37,7 @@ func NewInterface() (*Tun, error) {
 	return ifce, nil
 }
 
+// Configure configures the Tun interface
 func (tun *Tun) Configure(ifceAddr net.IP, remote net.IP, mtu string) error {
 	ipaddr := ifceAddr.String()
 	command := fmt.Sprintf("link set dev %s mtu %s", tun.Ifce.Name(), mtu)
@@ -58,10 +61,11 @@ func (tun *Tun) Configure(ifceAddr net.IP, remote net.IP, mtu string) error {
 		log.Printf("Error configuring interface %s, message: %s \n", tun.Ifce.Name(), err)
 		return err
 	}
-	tun.Ip = ifceAddr
+	tun.IP = ifceAddr
 	return nil
 }
 
+// GetDefaultGateway returns the default gateway on the host
 func GetDefaultGateway() (ifaceName string, gateway string, err error) {
 	routeFile, err := os.Open("/proc/net/route")
 	if err != nil {

--- a/internal/common/tplink.go
+++ b/internal/common/tplink.go
@@ -2,20 +2,26 @@ package common
 
 import (
 	"bytes"
-	"crypto"
 	"encoding/gob"
 	"log"
 	"net"
 )
 
 const (
-	HANDSHAKE            byte = 0x01
-	HANDSHAKE_ACCEPTED   byte = 0x02
+	// HANDSHAKE Initiates handshake
+	HANDSHAKE byte = 0x01
+	// HANDSHAKE_ACCEPTED accepts handshake
+	HANDSHAKE_ACCEPTED byte = 0x02
+	// CLIENT_CONFIGURATION sends client configuration
 	CLIENT_CONFIGURATION byte = 0x03
-	SESSION_REQUEST      byte = 0x04
-	SESSION_ACCEPTED     byte = 0x05
-	HEARTBEAT            byte = 0x06
-	SESSION              byte = 0x07
+	// SESSION_REQUEST requests for session
+	SESSION_REQUEST byte = 0x04
+	// SESSION_ACCEPTED accepts a session
+	SESSION_ACCEPTED byte = 0x05
+	// HEARTBEAT sends heartbeat
+	HEARTBEAT byte = 0x06
+	// SESSION sends session data
+	SESSION byte = 0x07
 )
 
 type Addr struct {
@@ -31,9 +37,9 @@ type PacketHeader struct {
 
 type Packet struct {
 	PacketHeader
-	PublicKey crypto.PublicKey
-	Payload   []byte
+	Payload []byte
 }
+
 type TCP struct {
 	Tcp_src     string
 	Tcp_dst     string

--- a/internal/common/tplink.go
+++ b/internal/common/tplink.go
@@ -24,29 +24,35 @@ const (
 	SESSION byte = 0x07
 )
 
+// Addr represents a HTTP address
 type Addr struct {
-	IpAddr  net.IP
+	IPAddr  net.IP
 	Network net.IPNet
 	Gateway net.IP
 }
 
+// PacketHeader represents header data in a packet
 type PacketHeader struct {
-	Flag byte
-	Plen uint16
+	Src   string
+	Flag  byte
+	Plen  uint16
+	Nonce []byte
 }
 
+// Packet is a structure representing a packet
 type Packet struct {
 	PacketHeader
 	Payload []byte
 }
 
+// TCP is a structure of a tcp datagram
 type TCP struct {
-	Tcp_src     string
-	Tcp_dst     string
-	Tcp_seq_num int
-	Tcp_ack_num int
-	Tcp_hdr_len int
-	Tcp_fin     []byte
+	TCPSrc    string
+	TCPDst    string
+	TCPSeqNum int
+	TCPackNum int
+	TCPHdrLen int
+	TCPFin    []byte
 }
 
 func Decode(dataStructure interface{}, data []byte) error {

--- a/internal/common/tplink.go
+++ b/internal/common/tplink.go
@@ -55,6 +55,7 @@ type TCP struct {
 	TCPFin    []byte
 }
 
+// Decode recieves data as a byte array and decodes it to the passed dataStructure
 func Decode(dataStructure interface{}, data []byte) error {
 	buffer := bytes.NewBuffer(data)
 	decoder := gob.NewDecoder(buffer)
@@ -68,6 +69,7 @@ func Decode(dataStructure interface{}, data []byte) error {
 	return nil
 }
 
+// Encode recieves a dataStructure to encode and returns an encoded byte array
 func Encode(dataStructure interface{}) (encoded []byte, err error) {
 	var buffer bytes.Buffer
 	encoder := gob.NewEncoder(&buffer)

--- a/internal/cryptography/ca.go
+++ b/internal/cryptography/ca.go
@@ -15,6 +15,7 @@ import (
 	"time"
 )
 
+// Cert represents a certificate details
 type Cert struct {
 	IsCA               bool
 	Country            string
@@ -29,6 +30,7 @@ type Cert struct {
 	ExpiryDate         string
 }
 
+// GenerateTemplate creates a certificate template
 func (cert *Cert) GenerateTemplate(privateKey *rsa.PrivateKey) (certificateTemplate *x509.Certificate) {
 	mathrand.Seed(time.Now().UnixNano())
 	randomInteger := mathrand.Intn(math.MaxInt64)
@@ -62,6 +64,7 @@ func (cert *Cert) GenerateTemplate(privateKey *rsa.PrivateKey) (certificateTempl
 	return template
 }
 
+// GenerateCA generates a certificate authority
 func (cert *Cert) GenerateCA() (privatekey *rsa.PrivateKey, publickey *rsa.PublicKey, certificate []byte, err error) {
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
@@ -78,6 +81,7 @@ func (cert *Cert) GenerateCA() (privatekey *rsa.PrivateKey, publickey *rsa.Publi
 	return privateKey, publicKey, caCert, nil
 }
 
+// GenerateClientCertificate generates client certificate from a certificate template, parent template and private key
 func (cert *Cert) GenerateClientCertificate(caTemplate *x509.Certificate, parentTemplate *x509.Certificate, caPrivateKey *rsa.PrivateKey) (privatekey *rsa.PrivateKey, publickey *rsa.PublicKey, certificate []byte, err error) {
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
@@ -101,6 +105,8 @@ func (cert *Cert) generateCert(caTemplate *x509.Certificate, parentTemplate *x50
 	return certBody, nil
 }
 
+// VerifyCertificate recieves a certificate and veriufies it against the root certificate
+// returning an error on failure and nil on success
 func VerifyCertificate(rootPEM []byte, certPEM []byte) error {
 	roots, _ := x509.SystemCertPool()
 	if roots == nil {
@@ -133,8 +139,12 @@ func VerifyCertificate(rootPEM []byte, certPEM []byte) error {
 	return nil
 }
 
+// HashBigInt creates a random serial number
 func HashBigInt(bigInt *big.Int) []byte {
 	hash := sha1.New()
-	hash.Write(bigInt.Bytes())
+	_, err := hash.Write(bigInt.Bytes())
+	if err != nil {
+		return nil
+	}
 	return hash.Sum(nil)
 }

--- a/internal/cryptography/codec.go
+++ b/internal/cryptography/codec.go
@@ -1,0 +1,49 @@
+package cryptography
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"io"
+	"log"
+)
+
+// Encrypt encrypts the plain text data
+func Encrypt(secret []byte, plainTextData []byte) (EncryptedData []byte, nonce []byte, err error) {
+	block, err := aes.NewCipher(secret)
+	if err != nil {
+		log.Println(err)
+		return nil, nil, err
+	}
+
+	nonce = make([]byte, 12)
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, nil, err
+	}
+
+	aesgcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, nil, err
+	}
+	EncryptedData = aesgcm.Seal(nil, nonce, plainTextData, nil)
+	return EncryptedData, nonce, nil
+}
+
+// Decrypt decrypts the plain text data
+func Decrypt(secret []byte, nonce []byte, encryptedData []byte) (plainText []byte, err error) {
+	block, err := aes.NewCipher(secret)
+	if err != nil {
+		log.Println(err)
+		return nil, err
+	}
+	aesgcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	plainText, err = aesgcm.Open(nil, nonce, encryptedData, nil)
+	if err != nil {
+		return nil, err
+	}
+	return plainText, nil
+}

--- a/internal/miniature/client.go
+++ b/internal/miniature/client.go
@@ -164,7 +164,7 @@ func (client *Client) AuthenticateUser() error {
 				log.Printf("Error deleting route message: %s \n", err)
 			}
 
-			command = fmt.Sprintf("route add 0.0.0.0/0 via %s dev %s", client.ifce.Ip.String(), client.ifce.Ifce.Name())
+			command = fmt.Sprintf("route add 0.0.0.0/0 via %s dev %s", client.ifce.IP.String(), client.ifce.Ifce.Name())
 			err = utilities.RunCommand("ip", command)
 			if err != nil {
 				log.Printf("Error adding route to 0.0.0.0/0, message: %s \n", err)
@@ -270,7 +270,7 @@ func (client *Client) StartHeartBeat() {
 // HeartBeat sends the client's heartbeat to the server
 func (client *Client) HeartBeat() {
 	peer := new(Peer)
-	peer.IP = client.ifce.Ip.String()
+	peer.IP = client.ifce.IP.String()
 	encodedPeer, err := utilities.Encode(&peer)
 	if err != nil {
 		log.Printf("An error occured while encording peer data \t Error : %s \n", err)

--- a/internal/miniature/server.go
+++ b/internal/miniature/server.go
@@ -476,7 +476,7 @@ func (server *Server) handleHandshake(conn net.Conn, payload []byte) error {
 	serverPrivateKey, serverPublicKey, err := serverKEX.GenerateKey(rand.Reader)
 	ip := server.getAvailableIP()
 	clientIPv4 := net.ParseIP(ip)
-	clientIP := utilities.Addr{IpAddr: clientIPv4, Network: *server.network, Gateway: server.tunInterface.Ip}
+	clientIP := utilities.Addr{IpAddr: clientIPv4, Network: *server.network, Gateway: server.tunInterface.IP}
 
 	handshakePacket := new(HandshakePacket)
 	handshakePacket.ClientIP = clientIP
@@ -617,10 +617,10 @@ func (server *Server) createIPPool() int {
 	log.Printf("The CIDR of this network is %s \n", server.network.String())
 	log.Printf("Generating IP address for %s network space \n", server.network)
 
-	ip := server.tunInterface.Ip
-	for ip := ip.Mask(server.network.Mask); server.network.Contains(ip); constructIP(ip) {
+	ip := server.tunInterface.IP
+	for ipAddr := ip.Mask(server.network.Mask); server.network.Contains(ip); constructIP(ip) {
 		// skip if ip is the same as the vitual interface's
-		if server.tunInterface.Ip.String() != ip.String() {
+		if server.tunInterface.IP.String() != ipAddr.String() {
 			server.ipPool = append(server.ipPool, ip.String())
 		} else {
 			log.Printf("Skipping the interface id %s \n", ip)


### PR DESCRIPTION
use AESGCM to encrypt data packets before they are sent to the server. The packets are encrypted with a nonce to prevent the chances of two packets getting encrypted the same way. Encryption and Decryption uses a pre-shared secret that is produced after the client and server have authenticated.

closes #11 