### PR TITLE
FT-M18: Find default gateway for osx

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -4,6 +4,10 @@ RUN apk upgrade
 RUN apk add git
 RUN apk add iptables
 RUN apk add bash
+RUN apk add curl
+RUN apk add net-tools
+RUN apk add tcpdump
+RUN apk add tshark
 RUN mkdir /miniature
 COPY . /miniature
 WORKDIR /miniature

--- a/go.mod
+++ b/go.mod
@@ -10,9 +10,8 @@ require (
 	github.com/songgao/water v0.0.0-20190623021929-8567d1527789
 	github.com/spacemonkeygo/openssl v0.0.0-20181017203307-c2dcc5cca94a // indirect
 	github.com/stretchr/testify v1.4.0
-	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 // indirect
-	golang.org/x/net v0.0.0-20190628185345-da137c7871d7
-	golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb
+	golang.org/x/net v0.0.0-20200707034311-ab3426394381
+	golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd
 	golang.org/x/text v0.3.2 // indirect
 	golang.org/x/tools v0.0.0-20190703172252-a00916dd39a5 // indirect
 	golang.org/x/tools/gopls v0.1.2-0.20190703172252-a00916dd39a5 // indirect

--- a/internal/common/helpers.go
+++ b/internal/common/helpers.go
@@ -80,6 +80,7 @@ func GetPublicIP(interfaceName string) (ipaddress string, err error) {
 	}
 
 	if len(strings.TrimSpace(publicIPAddress)) > 0 {
+		fmt.Println(publicIPAddress)
 		return publicIPAddress, nil
 	}
 	return "", errors.New("Could not find a public IP address")

--- a/internal/common/ifce.go
+++ b/internal/common/ifce.go
@@ -51,7 +51,7 @@ func (tun *Tun) Configure(ifceAddr net.IP, remote net.IP, mtu string) error {
 		}
 
 		tun.Mtu = mtu
-		command = fmt.Sprintf("addr add dev %s local %s peer %s", tun.Ifce.Name(), ipaddr, remote.String())
+		command = fmt.Sprintf("add add dev %s local %s peer %s", tun.Ifce.Name(), ipaddr, remote.String())
 		err = RunCommand("ip", command)
 		if err != nil {
 			log.Fatalf("Error configuring interface %s, message: %s \n", tun.Ifce.Name(), err)
@@ -64,16 +64,14 @@ func (tun *Tun) Configure(ifceAddr net.IP, remote net.IP, mtu string) error {
 			log.Printf("Error configuring interface %s, message: %s \n", tun.Ifce.Name(), err)
 			return err
 		}
-		tun.IP = ifceAddr
-		return nil
 	} else if runtime.GOOS == "darwin" {
-		command := fmt.Sprintf("ifconfig %s inet %s %s mtu %s up", tun.Ifce.Name(), ipaddr, remote.String(), mtu)
-		fmt.Println(command)
-		if err := exec.Command("ifconfig", tun.Ifce.Name(), "inet", ipaddr, remote.String(), "mtu", mtu, "up").Run(); err != nil {
+		command := fmt.Sprintf("%s inet %s %s mtu %s up", tun.Ifce.Name(), ipaddr, remote.String(), mtu)
+		if err := exec.Command("ifconfig", command).Run(); err != nil {
 			log.Fatalln("Unable to setup interface:", err)
 		}
 	}
-	fmt.Println(runtime.GOOS)
+
+	tun.IP = ifceAddr
 	return nil
 }
 

--- a/internal/common/ifce.go
+++ b/internal/common/ifce.go
@@ -3,11 +3,12 @@ package common
 import (
 	"bufio"
 	"encoding/hex"
+	"os/exec"
+
 	"fmt"
 	"log"
 	"net"
 	"os"
-	"os/exec"
 	"runtime"
 	"strings"
 
@@ -21,7 +22,7 @@ type Tun struct {
 	IP         net.IP
 	Remote     net.IP
 	SubnetMask net.IPMask
-	Mtu        string
+	Mtu        int
 }
 
 // NewInterface creates a new Tun interface
@@ -40,10 +41,10 @@ func NewInterface() (*Tun, error) {
 }
 
 // Configure configures the Tun interface
-func (tun *Tun) Configure(ifceAddr net.IP, remote net.IP, mtu string) error {
+func (tun *Tun) Configure(ifceAddr net.IP, remote net.IP, mtu int) error {
 	ipaddr := ifceAddr.String()
 	if runtime.GOOS == "linux" {
-		command := fmt.Sprintf("link set dev %s mtu %s", tun.Ifce.Name(), mtu)
+		command := fmt.Sprintf("link set dev %s mtu %d", tun.Ifce.Name(), mtu)
 		err := RunCommand("ip", command)
 		if err != nil {
 			log.Fatalf("Error configuring interface %s, message: %s \n", tun.Ifce.Name(), err)
@@ -65,9 +66,11 @@ func (tun *Tun) Configure(ifceAddr net.IP, remote net.IP, mtu string) error {
 			return err
 		}
 	} else if runtime.GOOS == "darwin" {
-		command := fmt.Sprintf("%s inet %s %s mtu %s up", tun.Ifce.Name(), ipaddr, remote.String(), mtu)
-		if err := exec.Command("ifconfig", command).Run(); err != nil {
+		command := fmt.Sprintf("%s inet %s %s up", tun.Ifce.Name(), ipaddr, remote.String())
+		fmt.Println(command)
+		if err := RunCommand("ifconfig", command); err != nil {
 			log.Fatalln("Unable to setup interface:", err)
+			return err
 		}
 	}
 
@@ -77,35 +80,61 @@ func (tun *Tun) Configure(ifceAddr net.IP, remote net.IP, mtu string) error {
 
 // GetDefaultGateway returns the default gateway on the host
 func GetDefaultGateway() (ifaceName string, gateway string, err error) {
-	routeFile, err := os.Open("/proc/net/route")
-	if err != nil {
-		log.Println("Error reading /proc/net/route")
-		return "", "", err
-	}
-	defer routeFile.Close()
-
-	scanner := bufio.NewScanner(routeFile)
-
-	lastline := 0
-	for scanner.Scan() {
-		lastline++
-		if lastline == 2 {
-			currentLine := scanner.Text()
-			splitEntries := strings.Split(currentLine, "\t")
-			ifaceName = splitEntries[0]
-			gateway = splitEntries[2]
-			break
+	if runtime.GOOS == "linux" {
+		routeFile, err := os.Open("/proc/net/route")
+		if err != nil {
+			log.Println("Error reading /proc/net/route")
+			return "", "", err
 		}
-	}
+		defer routeFile.Close()
 
-	// reverse gateway address
-	decodedGateway, err := hex.DecodeString(gateway)
+		scanner := bufio.NewScanner(routeFile)
 
-	if len(decodedGateway) != net.IPv4len {
-		log.Println("Error : This is not a valid IP address")
-		return "", "", fmt.Errorf("Invalid IPv4 address")
+		lastline := 0
+		for scanner.Scan() {
+			lastline++
+			if lastline == 2 {
+				currentLine := scanner.Text()
+				splitEntries := strings.Split(currentLine, "\t")
+				ifaceName = splitEntries[0]
+				gateway = splitEntries[2]
+				break
+			}
+		}
+
+		// reverse gateway address
+		decodedGateway, err := hex.DecodeString(gateway)
+
+		if len(decodedGateway) != net.IPv4len {
+			log.Println("Error : This is not a valid IP address")
+			return "", "", fmt.Errorf("Invalid IPv4 address")
+		}
+		ipAddr := net.IP([]byte{decodedGateway[3], decodedGateway[2], decodedGateway[1], decodedGateway[0]})
+		gateway = ipAddr.String()
+		return ifaceName, gateway, nil
+	} else if runtime.GOOS == "darwin" {
+		//route get default
+		routeCmd := exec.Command("/sbin/route", "-n", "get", "0.0.0.0")
+		output, err := routeCmd.CombinedOutput()
+		if err != nil {
+			return ifaceName, gateway, err
+		}
+
+		lines := strings.Split(string(output), "\n")
+		var iface, ip string
+		for _, line := range lines {
+			fields := strings.Fields(line)
+			if len(fields) >= 2 && fields[0] == "gateway:" {
+				ip = fields[1]
+			}
+			if len(fields) >= 2 && fields[0] == "interface:" {
+				iface = fields[1]
+			}
+		}
+		if len(iface) > 0 && len(ip) > 0 {
+			return iface, ip, nil
+		}
+		return iface, ip, nil
 	}
-	ipAddr := net.IP([]byte{decodedGateway[3], decodedGateway[2], decodedGateway[1], decodedGateway[0]})
-	gateway = ipAddr.String()
-	return ifaceName, gateway, nil
+	return " ", "", nil
 }

--- a/internal/miniature/client.go
+++ b/internal/miniature/client.go
@@ -154,6 +154,8 @@ func (client *Client) AuthenticateUser() error {
 
 			log.Println("Client has been assigned ", handshakePacket.ClientIP.IPAddr)
 			client.ifce = ifce
+			client.ifce.Mtu = "1400"
+			client.ifce.IP = handshakePacket.ClientIP.IPAddr
 
 			log.Printf("Starting session, MTU of link is %s \n", client.ifce.Mtu)
 
@@ -278,8 +280,10 @@ func (client *Client) handleOutgoingConnections() {
 			log.Printf("Version %d, Protocol  %d \n", header.Version, header.Protocol)
 			_, err = client.conn.Write(compressedPacket)
 			if err != nil {
+				fmt.Println(err)
 				break
 			}
+			fmt.Println(err)
 		}
 	}
 }

--- a/internal/miniature/compressor.go
+++ b/internal/miniature/compressor.go
@@ -2,6 +2,7 @@ package miniature
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/pierrec/lz4"
 )
@@ -25,7 +26,9 @@ func Compress(data []byte) (compressed []byte, err error) {
 
 // Decompress decompresses bytes passed to it and returns a decompressed byte array
 func Decompress(data []byte) (decompressedData []byte, err error) {
-	buff := make([]byte, 10*len(data))
+	buff := make([]byte, 100*len(data))
+	fmt.Println(len(buff))
+	fmt.Println(len(data))
 	n, err := lz4.UncompressBlock(data, buff)
 
 	if err != nil {

--- a/internal/miniature/compressor.go
+++ b/internal/miniature/compressor.go
@@ -2,7 +2,6 @@ package miniature
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/pierrec/lz4"
 )
@@ -27,10 +26,7 @@ func Compress(data []byte) (compressed []byte, err error) {
 // Decompress decompresses bytes passed to it and returns a decompressed byte array
 func Decompress(data []byte) (decompressedData []byte, err error) {
 	buff := make([]byte, 100*len(data))
-	fmt.Println(len(buff))
-	fmt.Println(len(data))
 	n, err := lz4.UncompressBlock(data, buff)
-
 	if err != nil {
 		return nil, err
 	}

--- a/internal/miniature/pool.go
+++ b/internal/miniature/pool.go
@@ -8,10 +8,11 @@ import (
 )
 
 type Pool struct {
-	Peers       map[string]*Peer
-	Reserve     []string
-	Mutex       *sync.Mutex
-	peerTimeOut float64
+	Peers          map[string]*Peer
+	Reserve        []string
+	NetworkAddress string
+	Mutex          *sync.Mutex
+	peerTimeOut    float64
 }
 
 // InitNodePool creates an empty nodepool and populates it with IP addresses
@@ -24,7 +25,7 @@ func InitNodePool(IPAddr string, network net.IPNet) *Pool {
 	log.Println(nodePool.peerTimeOut)
 
 	for addr := ipaddr.Mask(network.Mask); network.Contains(ipaddr); constructIP(ipaddr) {
-		if ipaddr.String() != addr.String() {
+		if !ipaddr.Equal(addr) {
 			nodePool.Reserve = append(nodePool.Reserve, ipaddr.String())
 		} else {
 			log.Printf("Skipping the interface id %s \n", addr.String())
@@ -33,6 +34,7 @@ func InitNodePool(IPAddr string, network net.IPNet) *Pool {
 	// pop out the first and last values from the generated IP pool
 	// first value is the subnet address
 	// last address is the broadcast address
+	nodePool.NetworkAddress = nodePool.Reserve[0]
 	nodePool.Reserve = nodePool.Reserve[1 : len(nodePool.Reserve)-1]
 
 	// start a timer to periodically remove dead peers and add them back to the reserve

--- a/internal/miniature/pool.go
+++ b/internal/miniature/pool.go
@@ -15,16 +15,15 @@ type Pool struct {
 }
 
 // InitNodePool creates an empty nodepool and populates it with IP addresses
-func InitNodePool(IPAddr net.IP, network net.IPNet) *Pool {
-	ipaddr := &IPAddr
-
+func InitNodePool(IPAddr string, network net.IPNet) *Pool {
+	ipaddr := net.ParseIP(IPAddr)
 	nodePool := new(Pool)
 	nodePool.Mutex = new(sync.Mutex)
 	nodePool.Peers = make(map[string]*Peer)
 	nodePool.peerTimeOut = float64(300)
 	log.Println(nodePool.peerTimeOut)
 
-	for addr := ipaddr.Mask(network.Mask); network.Contains(*ipaddr); constructIP(*ipaddr) {
+	for addr := ipaddr.Mask(network.Mask); network.Contains(ipaddr); constructIP(ipaddr) {
 		if ipaddr.String() != addr.String() {
 			nodePool.Reserve = append(nodePool.Reserve, ipaddr.String())
 		} else {

--- a/internal/miniature/server.go
+++ b/internal/miniature/server.go
@@ -467,6 +467,7 @@ func (server *Server) handleTLS(conn net.Conn) {
 		if packet.PacketHeader.Flag == utilities.HANDSHAKE {
 			err = server.handleHandshake(conn, packet.Payload)
 			if err != nil {
+				fmt.Println(err)
 				break
 			}
 		}
@@ -525,12 +526,12 @@ func (server *Server) handleHandshake(conn net.Conn, payload []byte) error {
 func (server *Server) listenAndServe() {
 	defer server.waiter.Done()
 
-	lstnAddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("0.0.0.0:%v", server.Config.ListeningPort))
+	lstnAddr, err := net.ResolveUDPAddr("udp4", fmt.Sprintf("0.0.0.0:%v", server.Config.ListeningPort))
 	if err != nil {
 		log.Fatalln("Unable to listen on UDP socket:", err)
 	}
 
-	lstnConn, err := net.ListenUDP("udp", lstnAddr)
+	lstnConn, err := net.ListenUDP("udp4", lstnAddr)
 	if err != nil {
 		log.Fatalln("Unable to listen on UDP socket:", err)
 	}

--- a/internal/miniature/server.go
+++ b/internal/miniature/server.go
@@ -526,14 +526,14 @@ func (server *Server) handleHandshake(conn net.Conn, payload []byte) error {
 func (server *Server) listenAndServe() {
 	defer server.waiter.Done()
 
-	lstnAddr, err := net.ResolveUDPAddr("udp4", fmt.Sprintf("0.0.0.0:%v", server.Config.ListeningPort))
+	lstnAddr, err := net.ResolveUDPAddr("udp6", fmt.Sprintf("%s:%v", server.Config.PublicIP, server.Config.ListeningPort))
 	if err != nil {
 		log.Fatalln("Unable to listen on UDP socket:", err)
 	}
 
-	lstnConn, err := net.ListenUDP("udp4", lstnAddr)
+	lstnConn, err := net.ListenUDP("udp6", lstnAddr)
 	if err != nil {
-		log.Fatalln("Unable to listen on UDP socket:", err)
+		log.Fatalln("Unable to listen on UDP socket111:", err)
 	}
 
 	server.socket = lstnConn

--- a/internal/miniature/server.go
+++ b/internal/miniature/server.go
@@ -66,6 +66,7 @@ type ServerConfig struct {
 	CertificatesDirectory string
 	Network               string
 	ListeningPort         int
+	PublicIP              string
 	Metadata              struct {
 		Country       string `yaml:"Country"`
 		Organization  string `yaml:"Organization"`
@@ -213,17 +214,9 @@ func (server *Server) CreateClientConfig() (yamlConfiguration string, errorMessa
 	if err != nil {
 		return "", err
 	}
-	ifceName, _, err := utilities.GetDefaultGateway()
-	if err != nil {
-		return "", err
-	}
 
-	publicIP, err := utilities.GetPublicIP(ifceName)
-	if err != nil {
-		return "", err
-	}
 	clientConfig := new(ClientConfig)
-	clientConfig.ServerAddress = publicIP
+	clientConfig.ServerAddress = server.Config.PublicIP
 	clientConfig.ListeningPort = server.Config.ListeningPort
 	clientConfig.PrivateKey = string(privateKeyBytes)
 	clientConfig.Certificate = string(certBytes)
@@ -255,12 +248,7 @@ func (server *Server) createCA() error {
 	cert.Province = server.Config.Metadata.Province
 	cert.StreetAddress = server.Config.Metadata.StreetAddress
 	cert.PostalCode = server.Config.Metadata.PostalCode
-
-	ipaddress, err := utilities.GetPublicIP(server.gatewayIfce)
-	if err != nil {
-		return err
-	}
-	cert.IPAddress = ipaddress
+	cert.IPAddress = server.Config.PublicIP
 	privateKey, publicKey, caCert, err := cert.GenerateCA()
 	if err != nil {
 		return err


### PR DESCRIPTION
In order to port the client to OSX, we should be able to find the default gateway for OSX devices. On top of finding the default gateway, this PR also fixes MTU issues that have been the cause of packets dropping while browsing large web pages.